### PR TITLE
take Spring out of gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,8 +41,8 @@ group :development do
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
-  gem 'spring'
-  gem 'spring-watcher-listen', '~> 2.0.0'
+  #gem 'spring'
+  #gem 'spring-watcher-listen', '~> 2.0.0'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,10 +212,6 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    spring (2.1.0)
-    spring-watcher-listen (2.0.1)
-      listen (>= 2.7, < 4.0)
-      spring (>= 1.2, < 3.0)
     sprockets (4.0.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -265,8 +261,6 @@ DEPENDENCIES
   rspec-rails (~> 4.0.0beta4)
   rspec_junit_formatter
   sass-rails (>= 6)
-  spring
-  spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)
   tzinfo-data
   web-console (>= 3.3.0)


### PR DESCRIPTION
It interferes with `bundle exec rails console` since we moved Gemfile into the parent directory, :( just don't use spring, my Rails app is not very big, I have lots of seconds to spare, and it's only ever caused me problems!