### PR TITLE
gitignore coverage/

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -37,3 +37,6 @@ template
 build
 rspec.xml
 features/reports/results.json
+coverage/
+coverage/index.html
+coverage/assets


### PR DESCRIPTION
run "bundle exec rspec" in the backend/ directory to review the coverage
report locally

(Browsing coverage reports on Codecov.io unfortunately does not work
because the Rails backend project was built in a subdirectory)